### PR TITLE
minor change

### DIFF
--- a/GetContours.m
+++ b/GetContours.m
@@ -1593,7 +1593,7 @@ if ~isempty(reSize) && reSize~=1,
 	end;
 
 % build interpolation indices
-	[ih,iw] = size(img);
+	[ih,iw,~] = size(img);
 	mih = floor(ih*reSize); miw = floor(iw*reSize);
 	[x,y] = meshgrid(1:(iw-1)/(miw-1):iw, 1:(ih-1)/(mih-1):ih);
 


### PR DESCRIPTION
There was a small problem whenever the 'RESIZE' option was used.  If frames (`img`) were 3d array (eg., `ih` x `iw` x `nImg`),  the width variable (`iw`) was multiplied by `nImg` in `[ih, iw] = size(img)`, so `iw` became enormously large number; therefore, a memory error occurred on Matlab when running line 1603 in `GetContours.m`.  The line 1596 was simply changed from `[ih, iw] = size(img)` to `[ih, iw, ~] = size(img)` to prevent this issue.